### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenTimelineIO
+# OpenTimelineIO-Plugins
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/AcademySoftwareFoundation/OpenTimelineIO/main/docs/_static/OpenTimelineIO@3xLight.png">
@@ -32,6 +32,7 @@ Links
 * Main web site: http://opentimeline.io/
 * Documentation: https://opentimelineio.readthedocs.io/
 * Main Project GitHub: https://github.com/AcademySoftwareFoundation/OpenTimelineIO
+* OpenTimelineIO-Plugins Github: https://github.com/OpenTimelineIO/OpenTimelineIO-Plugins
 * [Discussion group](https://lists.aswf.io/g/otio-discussion)
 * [Slack channel](https://academysoftwarefdn.slack.com/messages/CMQ9J4BQC)
   * To join, create an account here first: https://slack.aswf.io/


### PR DESCRIPTION
I came across the pypi listing for OpenTimeline-Plugins today - and it looked confusingly similar to the OpenTimeline page. 

I'm not sure how you want to handle the branding, or what the best way to deal with this is, but I proposed some simple changes in this commit 

![Screenshot 2024-06-20 at 9 34 19 AM](https://github.com/OpenTimelineIO/OpenTimelineIO-Plugins/assets/34345/fd857361-2a15-43c0-b8d0-a1b97d179090)

* Change title
* Add link to the OpenTimelineIO-Plugins github repo