### PR TITLE
Pyproject.toml cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,5 @@ Tracker = "https://github.com/OpenTimelineIO/OpenTimelineIO-Plugins/issues"
 support-legacy = true
 exclude = [".github"]
 
-[tool.hatch.metadata]
-# This should be removed after the OTIO reference no longer points to git
-allow-direct-references = true
-
+[tool.hatch.build.targets.wheel]
+packages = ["opentimelineio_plugins"]


### PR DESCRIPTION
- Removed allowance of git references for dependencies
- Added explicit declaration of stub python package