### PR TITLE
removed otio-hls-playlist-adapter and otio-fcpx-xml-adapter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,6 @@ dependencies = [
     "otio-burnins-adapter",
     "otio-xges-adapter",
     "otio-ale-adapter",
-    "otio-hls-playlist-adapter",
-    "otio-fcpx-xml-adapter",
     "otio-maya-sequencer-adapter",
     "otio-cmx3600-adapter",
     "otio-svg-adapter",


### PR DESCRIPTION
Fixes #11 

Removes unsupported FCP X XML and HLS Playlist adapters from the list of included adapters for the package.